### PR TITLE
Port to MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# Makefile for A09
+
+all: a09
+
+clean:
+	-$(RM) a09
+
+INSTALL := install
+INSTALL_PROGRAM := $(INSTALL)
+prefix := /usr/local
+exec_prefix := $(prefix)
+bindir := $(exec_prefix)/bin
+
+install: a09
+	$(INSTALL_PROGRAM) a09 $(bindir)/a09

--- a/a09.c
+++ b/a09.c
@@ -246,6 +246,7 @@ or http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefine
 || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)))
 	/* UNIX-style OS. ------------------------------------------- */
 #define UNIX 1                          /* set to != 0 for UNIX specials     */
+#include <unistd.h>	/* import unlink */
 #else
 #define UNIX 0                          /* set to != 0 for UNIX specials     */
 #endif

--- a/a09.c
+++ b/a09.c
@@ -239,10 +239,23 @@
 
 */
 
+/* @see https://stackoverflow.com/questions/2989810/which-cross-platform-preprocessor-defines-win32-or-win32-or-win32
+or http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system
+*/
+#if !defined(_WIN32) && !defined(_WIN64) && (defined(__unix__) \
+|| defined(__unix) || (defined(__APPLE__) && defined(__MACH__)))
+	/* UNIX-style OS. ------------------------------------------- */
+#define UNIX 1                          /* set to != 0 for UNIX specials     */
+#else
+#define UNIX 0                          /* set to != 0 for UNIX specials     */
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#if !UNIX
 #include <malloc.h>
+#endif
 #include <stdarg.h>
 #include <stdlib.h>
 #include <time.h>
@@ -254,7 +267,6 @@
 #define VERSION      "1.38"
 #define VERSNUM      "$0126"            /* can be queried as &VERSION        */
 
-#define UNIX 0                          /* set to != 0 for UNIX specials     */
 
 #define MAXLABELS    8192
 #define MAXMACROS    1024


### PR DESCRIPTION
The MacOS Clang compiler still gives one warning:

a09.c:3979:19: warning: address of array 'curline->txt' will always evaluate to
      'true' [-Wpointer-bool-conversion]
else if (curline->txt)                  /* otherwise                         */
     ~~  ~~~~~~~~~^~~

It's not obvious to me what the original intent was, so I didn't make any changes to address this issue.